### PR TITLE
Fixes #22 (WIP!)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3
 WORKDIR /work
 COPY requirements.txt /work
+COPY Procfile /work
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3
 WORKDIR /work
-COPY requirements.txt /work
-COPY Procfile /work
+COPY . ./
 RUN pip install -r requirements.txt

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: python manage.py migrate && python manage.py runserver "0.0.0.0:$PORT"
+web: python manage.py migrate || python manage.py runserver 0.0.0.0:$PORT
 celery: python manage.py celery

--- a/web.sh
+++ b/web.sh
@@ -1,0 +1,1 @@
+python manage.py migrate && python manage.py runserver "0.0.0.0:$PORT"


### PR DESCRIPTION
I fixed the Missing Procfile problem from #22 by copying it to the `WORKDIR`. Then, upon deploy, dokku couldn't find `manage,py`, so I copied everything to the `WORKDIR`. Problem is dokku seems to be passing `python manage.py runserver 0.0.0.0:$PORT` to `manage.py` as arguments, instead of running it as a separate command.