### PR TITLE
Add boot time checks to build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ ENV/
 db.sqlite3
 .vscode
 __pycache__
+.vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ db.sqlite3
 celerybeat-schedule
 repos/
 /static/
+.vagrant/
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ repos/
 /static/
 .vagrant/
 __pycache__/
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ git:
 services:
   - docker
 
+env:
+  - CHROMEDRIVER_PATH=/usr/lib/chromium-browser/chromedriver
+
 script:
   - sudo apt-get update
   - sudo apt-get install -y chromium-chromedriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,20 +11,4 @@ services:
   - docker
 
 script:
-  - REDIS_URL=dummy python manage.py test || travis_terminate 1
-  - wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | sudo apt-key add -
-  - echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ xenial main" | sudo tee /etc/apt/sources.list.d/dokku.list
-  - sudo apt-get update
-  - sudo apt-get install -y dokku
-  - sudo dokku plugin:install-dependencies --core
-  - sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
-  - sudo dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres
-  - sudo dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git
-  - dokku letsencrypt:cron-job --add
-  - dokku apps:create wharf
-  - dokku redis:create wharf && dokku redis:link wharf wharf
-  - dokku postgres:create wharf && dokku postgres:link wharf wharf
-  - git remote add dokku ssh://dokku@localhost/wharf
-  - yes y | ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa
-  - sudo dokku ssh-keys:add travis ~/.ssh/id_rsa.pub
-  - GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git push dokku HEAD:refs/heads/master
+  - ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ services:
   - docker
 
 script:
+  - sudo apt-get update
+  - sudo apt-get install -y chromium-chromedriver
   - ./test.sh

--- a/CHECKS
+++ b/CHECKS
@@ -1,1 +1,0 @@
-/status  All good

--- a/CHECKS
+++ b/CHECKS
@@ -1,0 +1,1 @@
+/status  All good

--- a/DOKKU_SCALE
+++ b/DOKKU_SCALE
@@ -1,0 +1,2 @@
+web=1
+celery=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3
-WORKDIR /work
-COPY requirements.txt /work
+WORKDIR /app
+COPY requirements.txt /app
 RUN pip install -r requirements.txt
-COPY . /work
+COPY . /app

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,6 @@ Vagrant.configure("2") do |config|
     curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
     echo "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable" | sudo tee /etc/apt/sources.list.d/docker.list
     pip3 install -r requirements.txt
-    ./test.sh
+    CHROMEDRIVER_PATH=/usr/bin/chromedriver ./test.sh
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,22 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian/stretch64"
+
+  config.vm.box_check_update = false
+  config.vm.synced_folder ".", "/vagrant", type: 'virtualbox'
+
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get install -y python3-pip git apt-transport-https curl
+    curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
+    echo "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable" | sudo tee /etc/apt/sources.list.d/docker.list
+    pip3 install -r requirements.txt
+    ./test.sh
+  SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   # end
 
   config.vm.provision "shell", inline: <<-SHELL
-    sudo apt-get install -y python3-pip git apt-transport-https curl redis-server
+    sudo apt-get install -y python3-pip git apt-transport-https curl redis-server chromium-driver
     curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
     echo "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable" | sudo tee /etc/apt/sources.list.d/docker.list
     pip3 install -r requirements.txt

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   # end
 
   config.vm.provision "shell", inline: <<-SHELL
-    sudo apt-get install -y python3-pip git apt-transport-https curl
+    sudo apt-get install -y python3-pip git apt-transport-https curl redis-server
     curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
     echo "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable" | sudo tee /etc/apt/sources.list.d/docker.list
     pip3 install -r requirements.txt

--- a/apps/templates/login.html
+++ b/apps/templates/login.html
@@ -23,7 +23,7 @@ and ADMIN_PASSWORD in the environment variables.
 </tr>
 </table>
 
-<input type="submit" value="login" />
+<input type="submit" value="login" name="submit" />
 <input type="hidden" name="next" value="{{ next }}" />
 </form>
 

--- a/apps/templates/setup_key.html
+++ b/apps/templates/setup_key.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body %}
-<h1>Wharf: Initial setup</h1>
+<h1 id="initial-setup-header">Wharf: Initial setup</h1>
 Save the following key (as one line) to a file on your server, and run the
 <code>ssh-keys:add</code> command from the <a href="http://dokku.viewdocs.io/dokku/deployment/user-management/#adding-ssh-keys">Dokku instructions for setting up SSH keys</a><br /><br />
 <code>

--- a/apps/urls.py
+++ b/apps/urls.py
@@ -5,6 +5,7 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('status', views.status, name='status'),
     path('refresh', views.refresh_all, name='refresh_all'),
     path('create_app', views.create_app, name='create_app'),
     path('global_config_set', views.global_config_set, name='global_config_set'),

--- a/apps/views.py
+++ b/apps/views.py
@@ -6,7 +6,7 @@ from celery.result import AsyncResult
 from celery.states import state, PENDING, SUCCESS, FAILURE, STARTED
 from django.core.cache import cache
 from django.views.decorators.csrf import csrf_exempt
-from django.http import HttpResponseBadRequest, HttpResponse
+from django.http import HttpResponseBadRequest, HttpResponse, HttpResponseServerError
 
 import requests
 import time
@@ -17,6 +17,7 @@ from datetime import datetime
 import json
 import hmac
 import hashlib
+import timeout_decorator
 
 from redis import StrictRedis
 
@@ -405,3 +406,19 @@ def github_webhook(request):
     ).save()
     clear_cache("config %s" % app.name)
     return HttpResponse("Running deploy. Deploy log is at %s" % request.build_absolute_uri(reverse('show_log', kwargs={'task_id': res.id})))
+
+@timeout_decorator.timeout(5, use_signals=False)
+def check_status():
+    # Clearing the cache and then trying a command makes sure that
+    # - The cache is up
+    # - Celery is up
+    # - We can run dokku commands
+    clear_cache("config --global")
+    run_cmd_with_cache("config --global")
+
+def status(request):
+    try:
+        check_status()
+        return HttpResponse("All good")
+    except timeout_decorator.TimeoutError:
+        return HttpResponseServerError("Timeout trying to get status")

--- a/apps/views.py
+++ b/apps/views.py
@@ -113,7 +113,7 @@ def index(request):
     try:
         apps = app_list()
     except Exception as e:
-        if e.__class__.__name__ == "AuthenticationException": # Can't use class directly as Celery mangles things
+        if e.__class__.__name__ in ["AuthenticationException", "NoValidConnectionsError"]: # Can't use class directly as Celery mangles things
             return render(request, 'setup_key.html', {'key': tasks.get_public_key.delay().get()})
         else:
             raise

--- a/check_boot.py
+++ b/check_boot.py
@@ -4,12 +4,13 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 import sys
+import os
 
 chrome_options = webdriver.ChromeOptions()
 chrome_options.headless = True
 chrome_options.add_argument('--headless')
 chrome_options.add_argument('--no-sandbox')
-driver = webdriver.Chrome(chrome_options=chrome_options, service_args=['--verbose'])
+driver = webdriver.Chrome(os.environ["CHROMEDRIVER_PATH"], chrome_options=chrome_options, service_args=['--verbose'])
 try:
     driver.get(sys.argv[1])
     driver.find_element_by_name("username").send_keys("admin")

--- a/check_boot.py
+++ b/check_boot.py
@@ -1,0 +1,22 @@
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import sys
+
+chrome_options = webdriver.ChromeOptions()
+chrome_options.headless = True
+chrome_options.add_argument('--headless')
+chrome_options.add_argument('--no-sandbox')
+driver = webdriver.Chrome(chrome_options=chrome_options, service_args=['--verbose'])
+try:
+    driver.get(sys.argv[1])
+    driver.find_element_by_name("username").send_keys("admin")
+    driver.find_element_by_name("password").send_keys("password")
+    driver.find_element_by_name("submit").click()
+    WebDriverWait(driver, 10).until(
+        EC.presence_of_element_located((By.ID, "initial-setup-header"))
+    )
+finally:
+    driver.quit()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     command: ./wait-for-it.sh postgres:5432 --strict --timeout=0 -- ./wait-for-it.sh redis:6379 --strict --timeout=0 -- bash -c "PORT=8000 ./dokku-boot.sh"
     volumes:
-      - .:/work
+      - .:/app
     ports:
       - 8000:8000
     environment:
@@ -23,7 +23,7 @@ services:
     build: .
     command: ./wait-for-it.sh postgres:5432 --strict --timeout=0 -- ./wait-for-it.sh redis:6379 --strict --timeout=0 -- bash -c "python manage.py celery"
     volumes:
-      - .:/work
+      - .:/app
     environment:
       - DATABASE_URL=postgres://postgres:example@postgres:5432/wharf
       - BROKER_URL=redis://redis:6379/0

--- a/requirements.in
+++ b/requirements.in
@@ -12,3 +12,4 @@ paramiko
 gitpython
 humanize
 timeout-decorator
+selenium

--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,4 @@ django-celery-results
 paramiko
 gitpython
 humanize
+timeout-decorator

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,8 +34,9 @@ pynacl==1.2.1             # via paramiko
 pytz==2018.4              # via celery, django
 redis==2.10.6             # via celery, django-redis
 requests==2.20.1
+selenium==3.141.0
 six==1.11.0               # via bcrypt, cryptography, pynacl
 smmap2==2.0.3             # via gitdb2
 timeout-decorator==0.4.1
-urllib3==1.24.1           # via requests
+urllib3==1.24.1           # via requests, selenium
 vine==1.1.4               # via amqp

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,5 +36,6 @@ redis==2.10.6             # via celery, django-redis
 requests==2.20.1
 six==1.11.0               # via bcrypt, cryptography, pynacl
 smmap2==2.0.3             # via gitdb2
+timeout-decorator==0.4.1
 urllib3==1.24.1           # via requests
 vine==1.1.4               # via amqp

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,7 @@ REDIS_URL=dummy python3 manage.py test
 wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | sudo apt-key add -
 echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ xenial main" | sudo tee /etc/apt/sources.list.d/dokku.list
 sudo apt-get update
-sudo apt-get install -y dokku
+sudo apt-get install -y dokku chromium-driver
 sudo dokku plugin:install-dependencies --core
 (dokku plugin:list | grep redis) || sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
 (dokku plugin:list | grep postgres) || sudo dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres
@@ -21,3 +21,4 @@ if [ ! -f ~/.ssh/id_rsa.pub ]; then
 fi
 (dokku ssh-keys:list | grep travis) || sudo dokku ssh-keys:add travis ~/.ssh/id_rsa.pub
 GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git push dokku HEAD:refs/heads/master
+python3 check_boot.py $(dokku url wharf)

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+REDIS_URL=dummy python3 manage.py test
+wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | sudo apt-key add -
+echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ xenial main" | sudo tee /etc/apt/sources.list.d/dokku.list
+sudo apt-get update
+sudo apt-get install -y dokku
+sudo dokku plugin:install-dependencies --core
+(dokku plugin:list | grep redis) || sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
+(dokku plugin:list | grep postgres) || sudo dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres
+(dokku plugin:list | grep letsencrypt) || sudo dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git
+dokku letsencrypt:cron-job --add
+(dokku apps:list | grep wharf) || dokku apps:create wharf
+(dokku redis:list | grep wharf) || (dokku redis:create wharf && dokku redis:link wharf wharf)
+(dokku postgres:list | grep wharf) || (dokku postgres:create wharf && dokku postgres:link wharf wharf)
+(git remote | grep dokku) || git remote add dokku ssh://dokku@localhost/wharf
+if [ ! -f ~/.ssh/id_rsa.pub ]; then
+    yes y | ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa
+fi
+(dokku ssh-keys:list | grep travis) || sudo dokku ssh-keys:add travis ~/.ssh/id_rsa.pub
+GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git push dokku HEAD:refs/heads/master

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,7 @@ REDIS_URL=dummy python3 manage.py test
 wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | sudo apt-key add -
 echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ xenial main" | sudo tee /etc/apt/sources.list.d/dokku.list
 sudo apt-get update
-sudo apt-get install -y dokku chromium-driver
+sudo apt-get install -y dokku
 sudo dokku plugin:install-dependencies --core
 (dokku plugin:list | grep redis) || sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
 (dokku plugin:list | grep postgres) || sudo dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres

--- a/wharf/settings.py
+++ b/wharf/settings.py
@@ -59,7 +59,7 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 LOGIN_REDIRECT_URL = "/"
-LOGIN_EXEMPT_URLS = ["webhook", "favicon.ico"]
+LOGIN_EXEMPT_URLS = ["webhook", "favicon.ico", "status"]
 
 ROOT_URLCONF = 'wharf.urls'
 


### PR DESCRIPTION
This PR explicitly adds some checks to the post-boot (not as CHECKS because those occur before the other containers get linked in, which isn't very useful), to make sure things actually come up (at least as far as the "celery is booted" step).

Along the way this also:
* Adds a DOKKU_SCALE so Celery actually boots
* Fixes the Paramiko exception bit for detecting the first-boot SSH key stuff
* Adds a Vagrantfile to help my local testing