### PR TITLE
Support existing apps

### DIFF
--- a/apps/views.py
+++ b/apps/views.py
@@ -282,7 +282,7 @@ def check_domain(request, app_name, task_id):
         raise Exception(data)
 
 def app_info(request, app_name):
-    app = models.App.objects.get(name=app_name)
+    app, _ = models.App.objects.get_or_create(name=app_name)
     config = app_config(app_name)
     if "GITHUB_URL" in config:
         app.github_url = config["GITHUB_URL"]

--- a/apps/views.py
+++ b/apps/views.py
@@ -242,7 +242,7 @@ def process_info(app_name):
         raise Exception(data)
     results = {}
     processes = {}
-    process_re = re.compile("Status\s+([^\.]+\.\d+)\s+(\S+)")
+    process_re = re.compile("Status\s+([^\.]+\.\d+):\s+(\S+)")
     for line in lines[1:]:
         if line.strip().startswith("Status "):
             matches = process_re.search(line)

--- a/apps/views.py
+++ b/apps/views.py
@@ -242,7 +242,7 @@ def process_info(app_name):
         raise Exception(data)
     results = {}
     processes = {}
-    process_re = re.compile("Status\s+([^\.]+\.\d+):\s+(\S+)")
+    process_re = re.compile("Status\s+([^\.]+\.\d+):?\s+(\S+)")
     for line in lines[1:]:
         if line.strip().startswith("Status "):
             matches = process_re.search(line)

--- a/check_boot.py
+++ b/check_boot.py
@@ -65,14 +65,21 @@ try:
         pass
     else:
         raise Exception(id)
-    app_name = uuid.uuid4().hex
-    print("Making new app " + app_name)
-    driver.find_element_by_id("id_name").send_keys(app_name)
-    driver.find_element_by_id("create_app").click()
+    # app_name = uuid.uuid4().hex
+    # print("Making new app " + app_name)
+    # driver.find_element_by_id("id_name").send_keys(app_name)
+    # driver.find_element_by_id("create_app").click()
+    # WebDriverWait(driver, 10).until(
+    #     lambda driver: wait_for_one(driver, [find_element_by_id("app_page")])
+    # )
+    # assert driver.page_source.find(app_name) != -1
+
+    driver.get(sys.argv[1])
+    driver.find_element_by_xpath('//a[text()="wharf"]').click()
     WebDriverWait(driver, 10).until(
         lambda driver: wait_for_one(driver, [find_element_by_id("app_page")])
     )
-    assert driver.page_source.find(app_name) != -1
+    assert driver.page_source.find("Wharf: wharf") != -1
 except:
     driver.get_screenshot_as_file('where.png')
     raise

--- a/check_boot.py
+++ b/check_boot.py
@@ -65,14 +65,14 @@ try:
         pass
     else:
         raise Exception(id)
-    # app_name = uuid.uuid4().hex
-    # print("Making new app " + app_name)
-    # driver.find_element_by_id("id_name").send_keys(app_name)
-    # driver.find_element_by_id("create_app").click()
-    # WebDriverWait(driver, 10).until(
-    #     lambda driver: wait_for_one(driver, [find_element_by_id("app_page")])
-    # )
-    # assert driver.page_source.find(app_name) != -1
+    app_name = uuid.uuid4().hex
+    print("Making new app " + app_name)
+    driver.find_element_by_id("id_name").send_keys(app_name)
+    driver.find_element_by_id("create_app").click()
+    WebDriverWait(driver, 10).until(
+        lambda driver: wait_for_one(driver, [find_element_by_id("app_page")])
+    )
+    assert driver.page_source.find(app_name) != -1
 
     driver.get(sys.argv[1])
     driver.find_element_by_xpath('//a[text()="wharf"]').click()


### PR DESCRIPTION
Some of the work in #33 removed support for apps made outside of Wharf, and this has been demonstrated in #39 which was broken by this.

This PR fixes that and tests them by going into the Wharf app itself during the test sequence.