### PR TITLE
Dokku 0.19.x fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     set -eux -o pipefail
     sudo apt-get update
-    sudo apt-get install --no-install-recommends -y build-essential python3-pip git apt-transport-https curl redis-server chromium-driver python3-setuptools python3-wheel python3-dev libssl-dev
+    sudo apt-get install --no-install-recommends -y build-essential python python3-pip git apt-transport-https curl redis-server chromium-driver python3-setuptools python3-wheel python3-dev libssl-dev
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
     echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable" | sudo tee /etc/apt/sources.list.d/docker.list
     cd /vagrant

--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,7 @@ if [ ! -f /etc/apt/sources.list.d/dokku.list ]; then
     echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ xenial main" | sudo tee /etc/apt/sources.list.d/dokku.list
     sudo apt-get update
 fi
+echo dokku dokku/skip_key_file boolean true | sudo debconf-set-selections
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y dokku
 sudo dokku plugin:install-dependencies --core
 (dokku plugin:list | grep redis) || sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis


### PR DESCRIPTION
- Copes with https://github.com/dokku/dokku/issues/3714
- Sets `dokku/skip_key_file` so the nginx setup works