### PR TITLE
Lockdown Python version for Wharf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - CHROMIUM_BROWSER=/usr/bin/chromium-browser
 
 script:
+  - docker build .
   - sudo apt-get update
   - sudo apt-get install -y chromium-chromedriver
   - chromium-browser --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ env:
     - CHROMIUM_BROWSER=/usr/bin/chromium-browser
 
 script:
-  - docker build .
-  - sudo apt-get update
-  - sudo apt-get install -y chromium-chromedriver
-  - chromium-browser --version
-  - which chromium-browser
-  - ./test.sh
+  - docker build . || travis_terminate 1
+  - sudo apt-get update || travis_terminate 1
+  - sudo apt-get install -y chromium-chromedriver || travis_terminate 1
+  - chromium-browser --version || travis_terminate 1
+  - which chromium-browser || travis_terminate 1
+  - ./test.sh || travis_terminate 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 WORKDIR /app
 COPY requirements.txt /app
 RUN pip install -r requirements.txt


### PR DESCRIPTION
3.8 in particular seems to break various of the dependencies, so lock down to 3.6 and test the build in Travis